### PR TITLE
Fix docstring brand reference

### DIFF
--- a/jaxabm/agent.py
+++ b/jaxabm/agent.py
@@ -1,7 +1,7 @@
 """
-Core abstractions for agents in the AgentJax framework.
+Core abstractions for agents in the JaxABM framework.
 
-This module defines the key abstractions for working with agents in 
+This module defines the key abstractions for working with agents in
 JAX-accelerated agent-based models, including agent types and collections.
 """
 


### PR DESCRIPTION
## Summary
- update `jaxabm/agent.py` opening docstring to reference JaxABM

## Testing
- `pytest -q tests/test_*` *(fails: ModuleNotFoundError: No module named 'jax')*

------
https://chatgpt.com/codex/tasks/task_b_684053637e708325b9a04d34b44a4caa