### PR TITLE
Fix agent count in jit_step

### DIFF
--- a/jaxabm/agent.py
+++ b/jaxabm/agent.py
@@ -1,7 +1,7 @@
 """
-Core abstractions for agents in the AgentJax framework.
+Core abstractions for agents in the JaxABM framework.
 
-This module defines the key abstractions for working with agents in 
+This module defines the key abstractions for working with agents in
 JAX-accelerated agent-based models, including agent types and collections.
 """
 

--- a/jaxabm/model.py
+++ b/jaxabm/model.py
@@ -342,4 +342,4 @@ class Model:
             return env_state, updated_agent_states, metrics, key
         
         # JIT-compile the step function
-        return jax.jit(_step_fn) 
+        return jax.jit(_step_fn)

--- a/jaxabm/model.py
+++ b/jaxabm/model.py
@@ -317,13 +317,20 @@ class Model:
                 # Get the update method directly
                 update_method = collection.agent_type.update
                 # Apply it across all agents with vmap
-                # Determine the number of agents from the first state array to
-                # avoid assuming a specific state variable name
-                num_agents = next(iter(states.values())).shape[0]
+                # Determine number of agents from any state variable
+                try:
+                    example_state = next(iter(states.values()))
+                    n_agents = example_state.shape[0]
+                except (StopIteration, AttributeError):
+                    raise ValueError(
+                        "Agent states must be a dictionary of arrays with at least one entry"
+                    )
+
                 updated_states = jax.vmap(
                     lambda agent_state, agent_key: update_method(
-                        agent_state, model_state, self.config, agent_key)
-                )(states, jax.random.split(subkey, num_agents))
+                        agent_state, model_state, self.config, agent_key
+                    )
+                )(states, jax.random.split(subkey, n_agents))
                 updated_agent_states[name] = updated_states
             
             # --- State Update Phase ---

--- a/jaxabm/model.py
+++ b/jaxabm/model.py
@@ -317,10 +317,13 @@ class Model:
                 # Get the update method directly
                 update_method = collection.agent_type.update
                 # Apply it across all agents with vmap
+                # Determine the number of agents from the first state array to
+                # avoid assuming a specific state variable name
+                num_agents = next(iter(states.values())).shape[0]
                 updated_states = jax.vmap(
                     lambda agent_state, agent_key: update_method(
                         agent_state, model_state, self.config, agent_key)
-                )(states, jax.random.split(subkey, states['position'].shape[0]))
+                )(states, jax.random.split(subkey, num_agents))
                 updated_agent_states[name] = updated_states
             
             # --- State Update Phase ---


### PR DESCRIPTION
## Summary
- calculate number of agents generically in `jit_step`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jax')*

------
https://chatgpt.com/codex/tasks/task_b_6840536cad9c8325be8ce7ca03dd0503