### PR TITLE
Fix outdated _model reference in AgentPy interface doc

### DIFF
--- a/docs/agentpy_interface.md
+++ b/docs/agentpy_interface.md
@@ -72,9 +72,9 @@ class MyModel(jx.Model):
         # (agents are stepped automatically)
         
         # Update environment
-        if hasattr(self._model, 'state'):
-            time = self._model.state['env'].get('time', 0)
-            self._model.add_env_state('time', time + 1)
+        if hasattr(self._jax_model, 'state'):
+            time = self._jax_model.state['env'].get('time', 0)
+            self._jax_model.add_env_state('time', time + 1)
         
         # Record data
         self.record('time', time)


### PR DESCRIPTION
## Summary
- update environment snippet to use `_jax_model`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pip install -e .` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_b_6840537997d483259428db43a4b21484